### PR TITLE
Add ability to use ?search query param on agents and users endpoints

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
@@ -1,3 +1,4 @@
+from rest_framework import filters
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from {{ cookiecutter.project_slug }}.core.filters import CamelCaseDjangoFilterBackend, CamelCaseOrderingFilter
@@ -11,9 +12,15 @@ class AgentViewSet(viewsets.ModelViewSet):
     queryset = Agent.objects.all()
     serializer_class = AgentSerializer
     permission_classes = (IsAuthenticated, IsAnyRole([User.EDITOR, User.USER, User.ADMIN]),)
-    filter_backends = (CamelCaseDjangoFilterBackend, CamelCaseOrderingFilter,)
+    filter_backends = (
+        filters.SearchFilter,
+        CamelCaseOrderingFilter,
+        CamelCaseDjangoFilterBackend,
+    )
     filterset_fields = {
         'email': ['icontains', 'startswith', 'endswith', 'exact'],
         'name': ['icontains', 'startswith', 'endswith', 'exact'],
         'phone_number': ['icontains', 'startswith', 'endswith', 'exact'],
     }
+    search_fields = ['email', 'name', 'phone_number']
+

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
@@ -3,6 +3,7 @@ from {{ cookiecutter.project_slug }}.users.email import ChangeEmailRequestEmail
 from djoser.serializers import UidAndTokenSerializer
 from {{ cookiecutter.project_slug }}.users.models import User
 from django.db import transaction
+from rest_framework import filters
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.decorators import action
@@ -19,12 +20,17 @@ from .permissions import IsAdmin, IsUserOrAdmin
 
 class UserViewSet(DjoserUserViewSet):
     permission_classes = (IsAuthenticated,)
-    filter_backends = (CamelCaseDjangoFilterBackend, CamelCaseOrderingFilter,)
+    filter_backends = (
+        filters.SearchFilter,
+        CamelCaseOrderingFilter,
+        CamelCaseDjangoFilterBackend,
+    )
     filterset_fields = {
         'email': ['icontains', 'startswith', 'endswith', 'exact'],
         'last_name': ['icontains', 'startswith', 'endswith', 'exact'],
         'first_name': ['icontains', 'startswith', 'endswith', 'exact'],
     }
+    search_fields = ['email', 'last_name', 'first_name']
 
     def perform_update(self, serializer):
         serializer.save()


### PR DESCRIPTION
Simply implement [DRF SearchFilter](https://www.django-rest-framework.org/api-guide/filtering/#searchfilter).

* This adds a `?search` query param to the endpoint that allows consumers of the api to search across multiple predefined field with a single query.