### PR TITLE
Add permissions to user_list views.

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/common.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/common.py
@@ -251,6 +251,7 @@ DJOSER = {
     "CHANGE_EMAIL_REQUEST_URL": "/auth/confirm-change-email/{uid}/{token}",
     "PERMISSIONS": {
         "user_delete": ["{{ cookiecutter.project_slug }}.users.permissions.IsAdmin"],
+        "user_list": ["{{ cookiecutter.project_slug }}.users.permissions.IsAdmin"],
     },
     "EMAIL": {
         "activation": "{{ cookiecutter.project_slug }}.users.email.ActivationEmail",


### PR DESCRIPTION
Ensure only admins can access the user list endpoint.

https://github.com/Shift3/boilerplate-client-react/issues/580