### PR TITLE
Refactored the Users Signals

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/apps.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/apps.py
@@ -6,4 +6,4 @@ class CoreConfig(AppConfig):
     name = "{{ cookiecutter.project_slug }}.users"
 
     def ready(self):
-        import {{ cookiecutter.project_slug }}.users.signals
+        from . import signals

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/apps.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "{{ cookiecutter.project_slug }}.users"
+
+    def ready(self):
+        import {{ cookiecutter.project_slug }}.users.signals

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/models.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/models.py
@@ -3,16 +3,11 @@ from django.contrib.auth.models import (
     BaseUserManager,
 )
 from django.db import models
-from django.conf import settings
-from django.dispatch import receiver
 from django.contrib.auth.models import AbstractUser
-from django.db.models.signals import post_save
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
-from djoser.signals import user_activated
 from easy_thumbnails.files import get_thumbnailer
-from rest_framework.authtoken.models import Token
 from simple_history.models import HistoricalRecords
 from easy_thumbnails.fields import ThumbnailerImageField
 from unique_upload import unique_upload
@@ -106,15 +101,3 @@ class User(AbstractUser, TimeStampedModel):
         if self.profile_picture:
             thumbnailer = get_thumbnailer(self.profile_picture)
             thumbnailer.delete(save=save)
-
-
-@receiver(user_activated)
-def save_activation_date(sender, user, request, **kwargs):
-    if user.activated_at is None:
-        user.activate()
-
-
-@receiver(post_save, sender=settings.AUTH_USER_MODEL)
-def create_auth_token(sender, instance=None, created=False, **kwargs):
-    if created:
-        Token.objects.create(user=instance)

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/signals.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/signals.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.dispatch import receiver
+from django.db.models.signals import post_save
+from djoser.signals import user_activated
+from rest_framework.authtoken.models import Token
+
+
+@receiver(user_activated)
+def save_activation_date(sender, user, request, **kwargs):
+    if user.activated_at is None:
+        user.activate()
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)


### PR DESCRIPTION
## Changes
1. Moved the signals to its own file and added it to `CoreConfig` to separate functionalities.

## Purpose
The signals at the bottom of the `models.py` file for the `users` app should be separated into another file called `signals.py`, and import it to the `ready()` method in the `CoreConfig` class so that Django knows its existence.