### PR TITLE
Supports the frontend branch that fixes the case-sensitive listview issue

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
@@ -28,7 +28,7 @@ class AgentViewSet(viewsets.ModelViewSet):
     filterset_fields = {
         "email": ["icontains", "startswith", "endswith", "iexact"],
         "name": ["icontains", "startswith", "endswith", "iexact"],
-        "phone_number": ["icontains", "startswith", "endswith", "exact"],
+        "phone_number": ["icontains", "startswith", "endswith", "iexact"],
     }
     search_fields = ["email", "name", "phone_number"]
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
@@ -26,8 +26,8 @@ class AgentViewSet(viewsets.ModelViewSet):
         CamelCaseDjangoFilterBackend,
     )
     filterset_fields = {
-        "email": ["icontains", "startswith", "endswith", "exact"],
-        "name": ["icontains", "startswith", "endswith", "exact"],
+        "email": ["icontains", "startswith", "endswith", "iexact"],
+        "name": ["icontains", "startswith", "endswith", "iexact"],
         "phone_number": ["icontains", "startswith", "endswith", "exact"],
     }
     search_fields = ["email", "name", "phone_number"]

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
@@ -34,9 +34,9 @@ class UserViewSet(DjoserUserViewSet):
         CamelCaseDjangoFilterBackend,
     )
     filterset_fields = {
-        "email": ["icontains", "startswith", "endswith", "exact"],
-        "last_name": ["icontains", "startswith", "endswith", "exact"],
-        "first_name": ["icontains", "startswith", "endswith", "exact"],
+        "email": ["icontains", "startswith", "endswith", "iexact"],
+        "last_name": ["icontains", "startswith", "endswith", "iexact"],
+        "first_name": ["icontains", "startswith", "endswith", "iexact"],
     }
     search_fields = ["email", "last_name", "first_name"]
 


### PR DESCRIPTION
## Changes
1. Changes `exact` to `iexact` for each of the filterset fields in the user/agent views

## Purpose
- Makes it so that the filtering is case-insensitive for all of the filterset fields for users and agents

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the react boilerplate under the branch with the same name
2. Follow the steps in the frontend version of this PR: https://github.com/Shift3/boilerplate-client-react/pull/594
