### PR TITLE
(cont.) Supports the frontend branch that fixes the case-sensitive listview issue

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/agents/views.py
@@ -26,9 +26,9 @@ class AgentViewSet(viewsets.ModelViewSet):
         CamelCaseDjangoFilterBackend,
     )
     filterset_fields = {
-        "email": ["icontains", "startswith", "endswith", "iexact"],
-        "name": ["icontains", "startswith", "endswith", "iexact"],
-        "phone_number": ["icontains", "startswith", "endswith", "iexact"],
+        "email": ["icontains", "istartswith", "iendswith", "iexact"],
+        "name": ["icontains", "istartswith", "iendswith", "iexact"],
+        "phone_number": ["icontains", "istartswith", "iendswith", "iexact"],
     }
     search_fields = ["email", "name", "phone_number"]
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
@@ -34,9 +34,9 @@ class UserViewSet(DjoserUserViewSet):
         CamelCaseDjangoFilterBackend,
     )
     filterset_fields = {
-        "email": ["icontains", "startswith", "endswith", "iexact"],
-        "last_name": ["icontains", "startswith", "endswith", "iexact"],
-        "first_name": ["icontains", "startswith", "endswith", "iexact"],
+        "email": ["icontains", "istartswith", "iendswith", "iexact"],
+        "last_name": ["icontains", "istartswith", "iendswith", "iexact"],
+        "first_name": ["icontains", "istartswith", "iendswith", "iexact"],
     }
     search_fields = ["email", "last_name", "first_name"]
 


### PR DESCRIPTION
## Changes
- Changes `startswith` and `endswith` to their case-insensitive versions in the user/agent views

## Purpose
- Makes it so that the filtering is case-insensitive for all of the filterset fields for users and agents

## Testing Steps
1. Pull in the changes to your local copy of this branch and run it alongside the react boilerplate under the branch with the same name
2. Follow the steps in the frontend version of this PR: https://github.com/Shift3/boilerplate-client-react/pull/596