### PR TITLE
Inherit dev from test to provide test tooling while in development.

### DIFF
--- a/{{ cookiecutter.project_slug }}/requirements/dev.txt
+++ b/{{ cookiecutter.project_slug }}/requirements/dev.txt
@@ -1,4 +1,4 @@
--r base.txt
+-r test.txt
 
 # Developer Tools
 ipdb==0.13.9


### PR DESCRIPTION
We want to allow people to access test tooling in development, so `dev` requirements now inherit from `test` instead of base.
