### PR TITLE
Don't truncate long sql queries in shell_plus

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
@@ -203,6 +203,10 @@ AUTH_USER_MODEL = "users.User"
 # Phone number setup
 PHONENUMBER_DEFAULT_REGION = "US"
 
+# Shell Plus (django-extensions)
+# https://django-extensions.readthedocs.io/en/latest/shell_plus.html#
+SHELL_PLUS_PRINT_SQL_TRUNCATE = None
+
 # Easy Thumbnailer
 THUMBNAIL_ALIASES = {
     # Global Aliases


### PR DESCRIPTION
When running `./manage.py shell_plus --print-sql` SQL queries are truncated to 1000 characters by default. Which is basically useless, this removes that truncation.