### PR TITLE
First and last page links were never added to the paginator.

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/core/pagination.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/core/pagination.py
@@ -1,6 +1,7 @@
 import math
 from rest_framework import pagination
 from rest_framework.response import Response
+from rest_framework.utils.urls import replace_query_param
 from django.conf import settings
 
 
@@ -9,21 +10,24 @@ class LinkedPagination(pagination.PageNumberPagination):
     page_size_query_param = "pageSize"
 
     def get_paginated_response(self, data):
+        url = self.request.build_absolute_uri()
+        first_page = 1
+        last_page = math.floor(self.page.paginator.count / self.page.paginator.per_page) + 1
+        page_count = math.ceil(self.page.paginator.count / self.page.paginator.per_page)
+
         return Response(
             {
                 "meta": {
-                    "pageCount": math.ceil(
-                        self.page.paginator.count / self.page.paginator.per_page
-                    ),
+                    "pageCount": page_count,
                     "pageSize": self.page.paginator.per_page,
                     "page": self.page.number,
                     "count": self.page.paginator.count,
                 },
                 "links": {
-                    "first": "",
+                    "first": replace_query_param(url, self.page_query_param, first_page),
                     "next": self.get_next_link(),
                     "prev": self.get_previous_link(),
-                    "last": "",
+                    "last": replace_query_param(url, self.page_query_param, last_page),
                 },
                 "results": data,
             }

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/core/pagination.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/core/pagination.py
@@ -12,8 +12,8 @@ class LinkedPagination(pagination.PageNumberPagination):
     def get_paginated_response(self, data):
         url = self.request.build_absolute_uri()
         first_page = 1
-        last_page = math.floor(self.page.paginator.count / self.page.paginator.per_page) + 1
         page_count = math.ceil(self.page.paginator.count / self.page.paginator.per_page)
+        last_page = max(page_count, 1)
 
         return Response(
             {


### PR DESCRIPTION
First and last page links were not filled out in the paginator. This branch adds those links, as they may be useful in the future if we make our paginator more linked based, and add first and last page buttons.

![image](https://user-images.githubusercontent.com/2287977/189705616-c7173949-4a62-49ad-9c07-5c1d43fb5b14.png)
