### PR TITLE
Expose Postgresql on host computer

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - POSTGRES_DB={{ cookiecutter.project_slug }}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
   web:
     restart: always
     environment:


### PR DESCRIPTION
This way you can use a database client/browser to access the database.
Since the method is "trust" you can login to your database using the
normal port 5432 and with the user postgres with no password.