### PR TITLE
Raise file upload limit in production/staging

### DIFF
--- a/{{ cookiecutter.project_slug }}/.circleci/config.yml
+++ b/{{ cookiecutter.project_slug }}/.circleci/config.yml
@@ -152,7 +152,7 @@ commands:
             mkdir -p .elasticbeanstalk
             cat \<<-EOF > .elasticbeanstalk/config.yml
             deploy:
-              artifact: Dockerrun.aws.json
+              artifact: artifact.zip
             global:
               application_name: <<parameters.eb_application_name>>
               default_platform: arn:aws:elasticbeanstalk:us-west-2::platform/Docker running on 64bit Amazon Linux/2.17.4
@@ -166,7 +166,7 @@ commands:
               workspace_type: Application
             EOF
       - run:
-          name: Generate Dockerrun.aws.json
+          name: Generate artifact.zip with Dockerrun.aws.json
           command: |-
             cat \<<-EOF > Dockerrun.aws.json
             {
@@ -182,6 +182,8 @@ commands:
               ]
             }
             EOF
+
+            zip -r artifact.zip Dockerrun.aws.json .platform
       - run:
           # Sends the generated Dockerrun.aws.json to eb, this tells EB
           # to pull from the image we just built, and pushed to ECR and

--- a/{{ cookiecutter.project_slug }}/.platform/nginx/conf.d/proxy.conf
+++ b/{{ cookiecutter.project_slug }}/.platform/nginx/conf.d/proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size 20M;

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/core/validators.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/core/validators.py
@@ -1,0 +1,16 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import MaxValueValidator
+from django.utils.translation import gettext_lazy as _
+from django.conf import settings
+
+def kilobytes(n):
+    return n * 1024;
+
+def megabytes(n):
+    return kilobytes(n) * 1024
+
+def image_size_validator(image):
+    if image.size > (megabytes(settings.MAX_IMAGE_UPLOAD_SIZE_MB)):
+        message = _('The file exceed the maximum size of %(max_size)s MB.')
+        params = {'max_size': settings.MAX_IMAGE_UPLOAD_SIZE_MB}
+        raise ValidationError(message, params=params)

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
@@ -330,3 +330,9 @@ EVENTSTREAM_ALLOW_ORIGIN = CLIENT_URL
 EVENTSTREAM_ALLOW_CREDENTIALS = True
 NOTIFICATION_TOKEN_EXPIRATION_SECONDS = 30
 {%- endif %}
+
+# When using the `image_size_validator`, this sets the maximum size
+# that will be accepted. Make sure that in production, your
+# nginx/apache is configure to accept body content up to or above the
+# size you set here.
+MAX_IMAGE_UPLOAD_SIZE_MB = 20

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/serializers.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from djoser import serializers as dj_serializers
 from djoser.conf import settings as djoser_settings
 from .models import User, HistoricalUser
+from ..core.validators import image_size_validator
 
 
 class ActivationSerializer(dj_serializers.ActivationSerializer):
@@ -56,11 +57,11 @@ class InviteUserSerializer(serializers.ModelSerializer):
         fields = ("email", "first_name", "last_name", "role")
 
 
-class ProfilePictureSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = ("profile_picture",)
-
+class ProfilePictureSerializer(serializers.Serializer):
+    file = serializers.ImageField(
+        max_length=100,
+        validators=[image_size_validator]
+    )
 
 class TokenSerializer(dj_serializers.TokenSerializer):
     user = UserSerializer(read_only=True, default=serializers.CurrentUserDefault())

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
@@ -132,7 +132,7 @@ class UserViewSet(DjoserUserViewSet):
         # Delete old profile picture if it exists
         user.delete_profile_picture(save=False)
 
-        user.profile_picture = request.data["file"]
+        user.profile_picture = serializer.validated_data["file"]
         user.save()
 
         serialized_user = UserSerializer(user, context={"request": request})


### PR DESCRIPTION
Production and staging were limited to the default file upload limit provided by nginx.

This PR:

* Adds an `image_size_validator`, and attaches it to the profile picture upload serializer.
* Creates a `MAX_IMAGE_UPLOAD_SIZE_MB` setting that affects the size check that the `image_size_validator` checks against.
* Bundles the deploy as a zip file, so that we (and developers) can utilize the `.platform` directory that amazon linux 2 provides us to tweak platform config files.
* Sets ElasticBeanstalks nginx to use a 20MB body size maximum instead of the default (1MB)