### PR TITLE
Adds translations for error, validation, and email messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The starter project is **Batteries Included**, meaning it comes with lots of hel
 
 * [Django](https://www.djangoproject.com/) is the framework that we are building on top of. If you are unfamiliar with django, it has a great [tutorial](https://www.djangoproject.com/start/) to get you introduced to the basic concepts.
 * [Django REST Framework](https://www.django-rest-framework.org/) (also known as DRF) specializes django to excel in serving a great API. It provides, serialization, authentication, and a browseable API that you can use in development to aid your API development experience.
+* [Django Translation](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/) is the system that allows django to translate web apps on the fly in each available language, according to the users' language preferences. This system includes i18n support out of the box.
 * [djoser](https://djoser.readthedocs.io/en/latest/introduction.html) provides a set of Django REST Framework endpoints that give us token authentication, registration, invitation, activation, forgot password, and other handy API endpoints for free.
 * [django-filter](https://django-filter.readthedocs.io/) integrated with DRF which provides us powerful filtering capabilities that our API endpoints can take advantage of.
 * [easy_thumbnails](https://github.com/SmileyChris/easy-thumbnails) which can automatically thumbnail user uploaded image files for optimized display on the frontend.

--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /code/
 COPY ./requirements requirements
 RUN pip install -r requirements/dev.txt
 
+# Install gettext in order to use Django's Translation system for internationalization support
+RUN apt-get update && apt-get install gettext -y
+
 # Adds our application code to the image
 WORKDIR /code/app
 COPY . /code/app

--- a/{{ cookiecutter.project_slug }}/Dockerfile.prod
+++ b/{{ cookiecutter.project_slug }}/Dockerfile.prod
@@ -6,6 +6,9 @@ WORKDIR /app
 COPY ./requirements requirements
 RUN pip install -r requirements/prod.txt
 
+# Install gettext in order to use Django's Translation system for internationalization support
+RUN apt-get update && apt-get install gettext -y
+
 COPY . .
 
 EXPOSE $PORT

--- a/{{ cookiecutter.project_slug }}/entrypoint.sh
+++ b/{{ cookiecutter.project_slug }}/entrypoint.sh
@@ -9,5 +9,8 @@ set -e
 # in settings.SEEDED_USER_EMAIL
 ./manage.py createsu
 
+# Compiles the translation files (.po) and generates their .mo counterparts
+./manage.py compilemessages
+
 # Run server and any workers
 honcho start -f Procfile.prod

--- a/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
+++ b/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
@@ -37,8 +37,8 @@ msgstr ""
 "Está recibiendo este correo electrónico porque es administrador y\n"
 "se ha creado un nuevo agente.\n"
 "\n"
-"Creado por: %(creado_por)s\n"
-"Agente: %(agente)s\n"
+"Creado por: %(created_by)s\n"
+"Agente: %(agent)s\n"
 "\n"
 
 #: {{ cookiecutter.project_slug }}/core/validators.py:14

--- a/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
+++ b/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: dj_starter_demo/agents/templates/notifications/agent_created_notification_email.html:5
+#: {{ cookiecutter.project_slug }}/agents/templates/notifications/agent_created_notification_email.html:5
 msgid "New agent created"
 msgstr ""
 
-#: dj_starter_demo/agents/templates/notifications/agent_created_notification_email.html:10
+#: {{ cookiecutter.project_slug }}/agents/templates/notifications/agent_created_notification_email.html:10
 #, python-format
 msgid ""
 "\n"
@@ -34,48 +34,48 @@ msgid ""
 "\n"
 msgstr ""
 
-#: dj_starter_demo/core/validators.py:14
+#: {{ cookiecutter.project_slug }}/core/validators.py:14
 #, python-format
 msgid "The file exceed the maximum size of %(max_size)s MB."
 msgstr "El archivo supera el tamaño máximo de %(max_size)s MB."
 
-#: dj_starter_demo/users/models.py:20
+#: {{ cookiecutter.project_slug }}/users/models.py:20
 msgid "The Email must be set"
 msgstr "El correo electrónico debe estar configurado"
 
-#: dj_starter_demo/users/models.py:53
+#: {{ cookiecutter.project_slug }}/users/models.py:53
 msgid "first name"
 msgstr ""
 
-#: dj_starter_demo/users/models.py:54
+#: {{ cookiecutter.project_slug }}/users/models.py:54
 msgid "last name"
 msgstr ""
 
-#: dj_starter_demo/users/models.py:62
+#: {{ cookiecutter.project_slug }}/users/models.py:62
 msgid "active"
 msgstr ""
 
-#: dj_starter_demo/users/models.py:65
+#: {{ cookiecutter.project_slug }}/users/models.py:65
 msgid ""
 "Designates whether this user should be treated as active. Unselect this "
 "instead of deleting accounts."
 msgstr ""
 
-#: dj_starter_demo/users/serializers.py:16
+#: {{ cookiecutter.project_slug }}/users/serializers.py:16
 msgid "Passwords must match."
 msgstr "Las contraseñas deben coincidir."
 
-#: dj_starter_demo/users/serializers.py:45
+#: {{ cookiecutter.project_slug }}/users/serializers.py:45
 msgid "A user with this email already exists."
 msgstr "Ya existe un usuario con este correo electrónico."
 
-#: dj_starter_demo/users/templates/email/change_email_request.html:5
+#: {{ cookiecutter.project_slug }}/users/templates/email/change_email_request.html:5
 #, python-format
 msgid "Email change request on %(site_name)s"
 msgstr "Solicitud de cambio de correo electrónico en %(site_name)s"
 
-#: dj_starter_demo/users/templates/email/change_email_request.html:10
-#: dj_starter_demo/users/templates/email/change_email_request.html:23
+#: {{ cookiecutter.project_slug }}/users/templates/email/change_email_request.html:10
+#: {{ cookiecutter.project_slug }}/users/templates/email/change_email_request.html:23
 #, python-format
 msgid ""
 "You're receiving this email because you requested a change of emails on "
@@ -84,26 +84,26 @@ msgstr ""
 "Estás recibiendo este correo electrónico porque solicitaste un cambio de correos electrónicos en "
 "%(site_name)s."
 
-#: dj_starter_demo/users/templates/email/change_email_request.html:12
-#: dj_starter_demo/users/templates/email/change_email_request.html:25
+#: {{ cookiecutter.project_slug }}/users/templates/email/change_email_request.html:12
+#: {{ cookiecutter.project_slug }}/users/templates/email/change_email_request.html:25
 msgid "Please go to the following page to complete the change email process:"
 msgstr "Vaya a la siguiente página para completar el proceso de cambio de correo electrónico:"
 
-#: dj_starter_demo/users/templates/email/change_email_request.html:17
-#: dj_starter_demo/users/templates/email/change_email_request.html:28
-#: dj_starter_demo/users/templates/email/custom_activation.html:21
-#: dj_starter_demo/users/templates/email/custom_activation.html:36
+#: {{ cookiecutter.project_slug }}/users/templates/email/change_email_request.html:17
+#: {{ cookiecutter.project_slug }}/users/templates/email/change_email_request.html:28
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:21
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:36
 #, python-format
 msgid "Regards, The %(site_name)s team"
 msgstr "Saludos, El equipo de %(site_name)s"
 
-#: dj_starter_demo/users/templates/email/custom_activation.html:5
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:5
 #, python-format
 msgid "Account activation on %(site_name)s"
 msgstr "Activación de cuenta en %(site_name)s"
 
-#: dj_starter_demo/users/templates/email/custom_activation.html:12
-#: dj_starter_demo/users/templates/email/custom_activation.html:29
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:12
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:29
 #, python-format
 msgid ""
 "You're receiving this email because you need to finish activation process on "
@@ -112,23 +112,23 @@ msgstr ""
 "Está recibiendo este correo electrónico porque necesita finalizar el proceso de activación el "
 "%(site_name)s."
 
-#: dj_starter_demo/users/templates/email/custom_activation.html:14
-#: dj_starter_demo/users/templates/email/custom_activation.html:31
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:14
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:31
 msgid "Please go to the following page to activate your account:"
 msgstr "Vaya a la siguiente página para activar su cuenta:"
 
-#: dj_starter_demo/users/templates/email/custom_activation.html:17
-#: dj_starter_demo/users/templates/email/custom_activation.html:34
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:17
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_activation.html:34
 msgid "This link will expire in 24 hours."
 msgstr "Este enlace caducará en 24 horas."
 
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:5
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:5
 #, python-format
 msgid "Password reset on %(site_name)s"
 msgstr "Restablecimiento de contraseña en %(site_name)s"
 
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:9
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:21
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:9
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:21
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
@@ -137,23 +137,23 @@ msgstr ""
 "Está recibiendo este correo electrónico porque solicitó un restablecimiento de contraseña para su "
 "cuenta de usuario en %(site_name)s."
 
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:11
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:23
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:11
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:23
 msgid "Please go to the following page and choose a new password:"
 msgstr "Vaya a la siguiente página y elija una nueva contraseña:"
 
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:13
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:25
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:13
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:25
 msgid "Your username, in case you've forgotten:"
 msgstr "Su nombre de usuario, en caso de que lo haya olvidado:"
 
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:15
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:27
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:15
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:27
 msgid "Thanks for using our site!"
 msgstr "¡Gracias por usar nuestro sitio!"
 
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:17
-#: dj_starter_demo/users/templates/email/custom_password_reset.html:29
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:17
+#: {{ cookiecutter.project_slug }}/users/templates/email/custom_password_reset.html:29
 #, python-format
 msgid "The %(site_name)s team"
 msgstr "El equipo de %(site_name)s"

--- a/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
+++ b/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: {{ cookiecutter.project_slug }}/agents/templates/notifications/agent_created_notification_email.html:5
 msgid "New agent created"
-msgstr ""
+msgstr "Nueva agente creada"
 
 #: {{ cookiecutter.project_slug }}/agents/templates/notifications/agent_created_notification_email.html:10
 #, python-format
@@ -33,6 +33,13 @@ msgid ""
 "Agent: %(agent)s\n"
 "\n"
 msgstr ""
+"\n"
+"Está recibiendo este correo electrónico porque es administrador y\n"
+"se ha creado un nuevo agente.\n"
+"\n"
+"Creado por: %(creado_por)s\n"
+"Agente: %(agente)s\n"
+"\n"
 
 #: {{ cookiecutter.project_slug }}/core/validators.py:14
 #, python-format

--- a/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
+++ b/{{ cookiecutter.project_slug }}/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,159 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-10-25 22:53+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: dj_starter_demo/agents/templates/notifications/agent_created_notification_email.html:5
+msgid "New agent created"
+msgstr ""
+
+#: dj_starter_demo/agents/templates/notifications/agent_created_notification_email.html:10
+#, python-format
+msgid ""
+"\n"
+"You're receiving this email because you are an administrator and a new\n"
+"agent has been created.\n"
+"\n"
+"Created By: %(created_by)s\n"
+"Agent: %(agent)s\n"
+"\n"
+msgstr ""
+
+#: dj_starter_demo/core/validators.py:14
+#, python-format
+msgid "The file exceed the maximum size of %(max_size)s MB."
+msgstr "El archivo supera el tamaño máximo de %(max_size)s MB."
+
+#: dj_starter_demo/users/models.py:20
+msgid "The Email must be set"
+msgstr "El correo electrónico debe estar configurado"
+
+#: dj_starter_demo/users/models.py:53
+msgid "first name"
+msgstr ""
+
+#: dj_starter_demo/users/models.py:54
+msgid "last name"
+msgstr ""
+
+#: dj_starter_demo/users/models.py:62
+msgid "active"
+msgstr ""
+
+#: dj_starter_demo/users/models.py:65
+msgid ""
+"Designates whether this user should be treated as active. Unselect this "
+"instead of deleting accounts."
+msgstr ""
+
+#: dj_starter_demo/users/serializers.py:16
+msgid "Passwords must match."
+msgstr "Las contraseñas deben coincidir."
+
+#: dj_starter_demo/users/serializers.py:45
+msgid "A user with this email already exists."
+msgstr "Ya existe un usuario con este correo electrónico."
+
+#: dj_starter_demo/users/templates/email/change_email_request.html:5
+#, python-format
+msgid "Email change request on %(site_name)s"
+msgstr "Solicitud de cambio de correo electrónico en %(site_name)s"
+
+#: dj_starter_demo/users/templates/email/change_email_request.html:10
+#: dj_starter_demo/users/templates/email/change_email_request.html:23
+#, python-format
+msgid ""
+"You're receiving this email because you requested a change of emails on "
+"%(site_name)s."
+msgstr ""
+"Estás recibiendo este correo electrónico porque solicitaste un cambio de correos electrónicos en "
+"%(site_name)s."
+
+#: dj_starter_demo/users/templates/email/change_email_request.html:12
+#: dj_starter_demo/users/templates/email/change_email_request.html:25
+msgid "Please go to the following page to complete the change email process:"
+msgstr "Vaya a la siguiente página para completar el proceso de cambio de correo electrónico:"
+
+#: dj_starter_demo/users/templates/email/change_email_request.html:17
+#: dj_starter_demo/users/templates/email/change_email_request.html:28
+#: dj_starter_demo/users/templates/email/custom_activation.html:21
+#: dj_starter_demo/users/templates/email/custom_activation.html:36
+#, python-format
+msgid "Regards, The %(site_name)s team"
+msgstr "Saludos, El equipo de %(site_name)s"
+
+#: dj_starter_demo/users/templates/email/custom_activation.html:5
+#, python-format
+msgid "Account activation on %(site_name)s"
+msgstr "Activación de cuenta en %(site_name)s"
+
+#: dj_starter_demo/users/templates/email/custom_activation.html:12
+#: dj_starter_demo/users/templates/email/custom_activation.html:29
+#, python-format
+msgid ""
+"You're receiving this email because you need to finish activation process on "
+"%(site_name)s."
+msgstr ""
+"Está recibiendo este correo electrónico porque necesita finalizar el proceso de activación el "
+"%(site_name)s."
+
+#: dj_starter_demo/users/templates/email/custom_activation.html:14
+#: dj_starter_demo/users/templates/email/custom_activation.html:31
+msgid "Please go to the following page to activate your account:"
+msgstr "Vaya a la siguiente página para activar su cuenta:"
+
+#: dj_starter_demo/users/templates/email/custom_activation.html:17
+#: dj_starter_demo/users/templates/email/custom_activation.html:34
+msgid "This link will expire in 24 hours."
+msgstr "Este enlace caducará en 24 horas."
+
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:5
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr "Restablecimiento de contraseña en %(site_name)s"
+
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:9
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:21
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at %(site_name)s."
+msgstr ""
+"Está recibiendo este correo electrónico porque solicitó un restablecimiento de contraseña para su "
+"cuenta de usuario en %(site_name)s."
+
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:11
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:23
+msgid "Please go to the following page and choose a new password:"
+msgstr "Vaya a la siguiente página y elija una nueva contraseña:"
+
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:13
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:25
+msgid "Your username, in case you've forgotten:"
+msgstr "Su nombre de usuario, en caso de que lo haya olvidado:"
+
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:15
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:27
+msgid "Thanks for using our site!"
+msgstr "¡Gracias por usar nuestro sitio!"
+
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:17
+#: dj_starter_demo/users/templates/email/custom_password_reset.html:29
+#, python-format
+msgid "The %(site_name)s team"
+msgstr "El equipo de %(site_name)s"

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
@@ -71,6 +71,7 @@ MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -104,7 +105,10 @@ TIME_ZONE = "UTC"
 LANGUAGE_CODE = "en-us"
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
-USE_I18N = False
+USE_I18N = True
+LOCALE_PATHS = (
+    os.path.join(BASE_DIR, "locale"),
+)
 USE_TZ = True
 LOGIN_REDIRECT_URL = "/"
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/serializers.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/serializers.py
@@ -4,6 +4,7 @@ from djoser import serializers as dj_serializers
 from djoser.conf import settings as djoser_settings
 from .models import User, HistoricalUser
 from ..core.validators import image_size_validator
+from django.utils.translation import gettext_lazy as _
 
 
 class ActivationSerializer(dj_serializers.ActivationSerializer):
@@ -12,7 +13,7 @@ class ActivationSerializer(dj_serializers.ActivationSerializer):
 
     def validate_password(self, value):
         if value != self.initial_data["password_confirmation"]:
-            raise serializers.ValidationError("Passwords must match.")
+            raise serializers.ValidationError(_("Passwords must match."))
         return value
 
 
@@ -41,7 +42,7 @@ class ChangeEmailRequestSerializer(serializers.Serializer):
 
     def validate_email(self, value):
         if User.objects.filter(email=value).exists():
-            raise serializers.ValidationError("A user with this email already exists.")
+            raise serializers.ValidationError(_("A user with this email already exists."))
         return value
 
 


### PR DESCRIPTION
## Changes
1. Activates Django's Translation system
2. Marked some serializer strings as translation strings
3. Added the locale directory and the translation file for spanish
4. Added the gettest installation line to the Dockerfile

## Purpose
Adds translations for error, validation, and email messages

## Approach
Uses Django's Translation system in order to have error, validation, and email messages be dependent on what value is set in the "Accept-Language" header on the frontend.

## Note
@DropsOfSerenity I don't think I'm covering everything. Do you know if there is anything that I'm missing?

## Screenshots

### If you try to change your email to an email that is already being used:

![change-email-validation-error](https://user-images.githubusercontent.com/2876874/198158786-9c0c1daf-d615-4686-9296-27efc3e212b7.png)

### Email associated with changing your email address

![translated email](https://user-images.githubusercontent.com/2876874/198158807-b627a95c-a1e0-453a-a287-58f2a2c89a3c.png)

### Image upload size error (Note: For testing purposes, I set the image size limit to 1 MB.)

![translated image upload error](https://user-images.githubusercontent.com/2876874/198158852-6b958f14-52d5-47d4-b542-690e2e555fe2.png)

## Testing Steps
1. You can test these changes by using the branch with the same name on the dj_starter_demo repo. I made these changes there first.
2. When the backend is running, you should compile the translation strings by first running `docker-compose exec web bash` and then `django-admin compilemessages`.
3. You should also use the frontend branch by the same name.

## Learning
The following links were very helpful:
- [Translation](https://docs.djangoproject.com/en/4.0/topics/i18n/translation/#translation)
- [Middleware](https://docs.djangoproject.com/en/4.0/ref/middleware/)
- [A Quick Intro to Translation in Django (Internationalization)](https://www.youtube.com/watch?v=AlJ8cGbk8ps)