### PR TITLE
Use SITE_NAME

### DIFF
--- a/{{ cookiecutter.project_slug }}/prod.tfvars
+++ b/{{ cookiecutter.project_slug }}/prod.tfvars
@@ -36,5 +36,6 @@ eb_env_variables = {
   DJANGO_SECRET_KEY      = "{{ random_ascii_string(32) }}"
   DJANGO_SETTINGS_MODULE = "{{ cookiecutter.project_slug }}.settings.prod"
   SEEDED_USER_EMAIL      = "{{ cookiecutter.admin_email }}"
+  SITE_NAME              = "{{ cookiecutter.project_name }}"
   NEW_RELIC_ENVIRONMENT  = "production"
 }

--- a/{{ cookiecutter.project_slug }}/staging.tfvars
+++ b/{{ cookiecutter.project_slug }}/staging.tfvars
@@ -36,5 +36,6 @@ eb_env_variables = {
   DJANGO_SECRET_KEY      = "{{ random_ascii_string(32) }}"
   DJANGO_SETTINGS_MODULE = "{{ cookiecutter.project_slug }}.settings.staging"
   SEEDED_USER_EMAIL      = "{{ cookiecutter.admin_email }}"
+  SITE_NAME              = "{{ cookiecutter.project_name }}"
   NEW_RELIC_ENVIRONMENT  = "staging"
 }

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
@@ -19,6 +19,10 @@ env.read_env(os.path.join(BASE_DIR, ".env"))
 ALLOWED_HOSTS = ["*"]
 DEBUG = env.bool("DJANGO_DEBUG", False)
 
+# We avoid using the django sites framework in favor of a more simple
+# configuration option here
+SITE_NAME = env.str("SITE_NAME", "Starter Project")
+
 SERVER_URL = env.str("SERVER_URL", "http://localhost:8000")
 CLIENT_URL = env.str("CLIENT_URL", "http://localhost:4200")
 DEFAULT_FROM_EMAIL = f'no-reply@{env.str("EMAIL_DOMAIN", "localhost")}'


### PR DESCRIPTION
* Since we don't enable the more complicated django sites framework, we can simply set the SITE_NAME configuration to use it in templates.
* Modifies the generate terraform variable files to include an environment variable for SITE_NAME based on what the user enters as the `project_name`
