### PR TITLE
Programatically invoke uvicorn for development server.

### DIFF
--- a/{{ cookiecutter.project_slug }}/Procfile
+++ b/{{ cookiecutter.project_slug }}/Procfile
@@ -1,2 +1,2 @@
-web: uvicorn {{ cookiecutter.project_slug }}.asgi:application --reload --host 0.0.0.0 --port $PORT
+web: python run.py
 worker: ./manage.py rundramatiq --processes 1 --threads 1

--- a/{{ cookiecutter.project_slug }}/run.py
+++ b/{{ cookiecutter.project_slug }}/run.py
@@ -1,0 +1,21 @@
+# Development uvicorn configuration that allows us to terminate open socket
+# connections during reload in development. ONLY USE IN DEVELOPMENT.
+
+import uvicorn
+from uvicorn.supervisors import ChangeReload
+
+if __name__ == "__main__":
+    config = uvicorn.Config(
+        "{{ cookiecutter.project_slug }}.asgi:application",
+        port=8000,
+        reload=True,
+        debug=True,
+        reload_includes=["*.py", "*.html"],
+        host="0.0.0.0",
+    )
+    server = uvicorn.Server(config)
+    server.force_exit = True
+
+    sock = config.bind_socket()
+    supervisor = ChangeReload(config, target=server.run, sockets=[sock])
+    supervisor.run()


### PR DESCRIPTION
Invoke uvicorn from a python program so that we can configure it to terminate connections when detects a file changed and it needs to be reloaded.

Before this change uvicorn would hang open when a SSE event listener was connected from the frontend, this would prevent a server reload until that frontend connection was closed (with say a refresh).