### PR TITLE
Create a postgresql user `admin` in development.

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: postgres:14.2
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_USER=admin
       - POSTGRES_DB={{ cookiecutter.project_slug }}
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/base.py
@@ -98,7 +98,7 @@ ADMINS = (("Author", "jschiff@bitwiseindustries.com"),)
 # Postgres
 DATABASES = {
     "default": dj_database_url.config(
-        default="postgres://postgres:@postgres:5432/{{ cookiecutter.project_slug }}",
+        default="postgres://admin:@postgres:5432/{{ cookiecutter.project_slug }}",
         conn_max_age=env.int("POSTGRES_CONN_MAX_AGE", 600),
     )
 }
@@ -330,7 +330,7 @@ TWILIO_AUTH_TOKEN = env.str("TWILIO_AUTH_TOKEN", None)
 {%- if cookiecutter.include_notifications == "yes" %}
 # Django Eventstream
 # https://github.com/fanout/django-eventstream
-# 
+#
 # Enables the easy use of SSE (Server sent events) we use this for
 # notifications.
 # EVENTSTREAM_CHANNELMANAGER_CLASS = '{{ cookiecutter.project_slug }}.core.channelmanager.UserChannelManager'


### PR DESCRIPTION
To be less confusing for developers, specify an admin database user instead of relying on the default postgresql user `postgres`.
