### PR TITLE
Users can no longer change their own role

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/permissions.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/permissions.py
@@ -14,7 +14,6 @@ def IsAnyRole(role_list):
 
 IsAdmin = IsAnyRole([User.ADMIN])
 
-
 class IsUserOrReadOnly(permissions.BasePermission):
     """
     Object-level permission to only allow owners of an object to edit it.

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/users/views.py
@@ -44,7 +44,17 @@ class UserViewSet(DjoserUserViewSet):
     }
     search_fields = ["email", "last_name", "first_name"]
 
+    def make_role_read_only(self, serializer):
+        serializer.validated_data.pop('role', None)
+
     def perform_update(self, serializer):
+        user_being_accessed = self.get_object()
+        user_making_request = self.request.user
+        is_same_user = (user_being_accessed == user_making_request)
+
+        if is_same_user or user_being_accessed.role == "USER" or user_being_accessed.role == "EDITOR":
+            self.make_role_read_only(serializer)
+
         serializer.save()
 
     @action(


### PR DESCRIPTION
## Changes
1. Edits the perform_update method in the UserViewSet so that admins and non-admins can't change their own role. Additionally, the role of admins can't be changed (ex. by other admins) and non-admins can't change the role of other accounts.

## Purpose
The user can no longer change their own role.

## Approach
This change makes it so that the `perform_update` method removes the role field from the validated_data dictionary of the serializer in the following circumstances:

- The logged in user is the same as the user that is being accessed.
- The logged in user is a USER or an EDITOR.
- The role of an ADMIN is being changed.

By doing so, the role field will be ignored during the update process, effectively preventing users from changing their role through the API.

## Testing Steps
1. Use the same branch on the dj_starter_demo repo
2. Create an admin user and a user/editor
3. Log in as the admin via the DRF interface. Go to its instance (ex. `http://localhost:8000/users/d88e51a9-a649-4d35-aa2f-a0ec3e8c70be/`) and try to change the admin's role. The value for the admin's role won't be updated.
4. Try to change the role of the other user/editor that you created. This operation will succeed.

## Learning
- I used ChatGPT in order to understand how the perform_update method of Djoser's UserViewSet view could be used to restrict users from changing their own role.